### PR TITLE
Add User Point in Datastore

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,24 @@
       <version>1.9.59</version>
     </dependency>
     <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-testing</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-stubs</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-tools-sdk</artifactId>
+      <version>1.9.59</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>libraries-bom</artifactId>
       <version>3.0.0</version>

--- a/src/main/java/com/google/songgame/data/GuessChecker.java
+++ b/src/main/java/com/google/songgame/data/GuessChecker.java
@@ -33,7 +33,7 @@ public final class GuessChecker {
     return game;
   }
 
-  public static Entity assignUserPoint(Entity user, Entity game) {
+  public static Entity assignUserPoints(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
     EmbeddedEntity userPoints = (EmbeddedEntity) game.getProperty("userPoints");
     long currentUserPoints = (Long) userPoints.getProperty(userId);

--- a/src/main/java/com/google/songgame/data/GuessChecker.java
+++ b/src/main/java/com/google/songgame/data/GuessChecker.java
@@ -1,0 +1,5 @@
+package com.google.songgame.data;
+
+public final class GuessChecker {
+  public static 
+}

--- a/src/main/java/com/google/songgame/data/GuessChecker.java
+++ b/src/main/java/com/google/songgame/data/GuessChecker.java
@@ -2,16 +2,20 @@ package com.google.songgame.data;
 
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EmbeddedEntity;
+import com.google.cloud.datastore.testing.LocalDatastoreHelper;
 
 /**
- * Contains various helper methods revolving around checking a users guess including checking whether a user has already correctly guessed, whether a guess is correct, and updating the game state if a user has guessed correctly
+ * Contains various helper methods revolving around checking a users guess including checking
+ * whether a user has already correctly guessed, whether a guess is correct, and updating the game
+ * state if a user has guessed correctly
  */
 public final class GuessChecker {
-  private static final int POINTS_PER_ROUND = 100;
+  private static final long POINTS_PER_ROUND = 100;
   /**
    * Checks if the user has already guessed correctly.
-   * 
-   * <p>Checks for the current round if the user has already guessed correctly and returns true or false
+   *
+   * <p>Checks for the current round if the user has already guessed correctly and returns true or
+   * false
    */
   public static boolean hasUserPreviouslyGuessedCorrect(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
@@ -24,8 +28,9 @@ public final class GuessChecker {
 
   /**
    * Checks if the given guess is correct.
-   * 
-   * <p>Checks if the guess is correct and matches the video title of the current round, ignoring case
+   *
+   * <p>Checks if the guess is correct and matches the video title of the current round, ignoring
+   * case
    */
   public static boolean isCorrectGuess(String guess, Entity game) {
     EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
@@ -37,8 +42,9 @@ public final class GuessChecker {
 
   /**
    * Updates the game state to indicate the user has correctly guessed
-   * 
-   * <p>Updates for the current round that the user has guessed correctly. Updates in the userGuessStatuses map stored in the currentRound entity of the game.
+   *
+   * <p>Updates for the current round that the user has guessed correctly. Updates in the
+   * userGuessStatuses map stored in the currentRound entity of the game.
    */
   public static Entity markUserGuessedCorrectly(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
@@ -49,10 +55,10 @@ public final class GuessChecker {
     game.setProperty("currentRound", currentRound);
     return game;
   }
-  
+
   /**
    * Updates the game state by increasing the users points
-   * 
+   *
    * <p>Updates for the given user the point total. Updates in the userPoints map.
    */
   public static Entity assignUserPoints(Entity user, Entity game) {

--- a/src/main/java/com/google/songgame/data/GuessChecker.java
+++ b/src/main/java/com/google/songgame/data/GuessChecker.java
@@ -1,5 +1,44 @@
 package com.google.songgame.data;
 
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+
 public final class GuessChecker {
-  public static 
+  private final static int POINTS_PER_ROUND = 100;
+
+  public static boolean hasUserPreviouslyGuessed(Entity user, Entity game) {
+    String userId = (String) user.getProperty("userId");
+    EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
+    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+    boolean userGuessStatus = (Boolean) userGuessStatuses.getProperty(userId);
+    return userGuessStatus;
+  }
+
+  public static boolean isCorrectGuess(String guess, Entity game) {
+    EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
+    EmbeddedEntity currentVideo = (EmbeddedEntity) currentRound.getProperty("video");
+    String videoTitle = (String) currentVideo.getProperty("title");
+    String guess = message.toLowerCase();
+    return guess.equals(videoTitle);
+  }
+
+  public static Entity markUserGuessedCorrectly(Entity user, Entity game) {
+    String userId = (String) user.getProperty("userId");
+    EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentROund");
+    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+    userGuessStatuses.setProperty(userId, true);
+    game.setProperty("currentRound", currentRound);
+    return game;
+  }
+
+  public static Entity assignUserPoint(Entity user, Entity game) {
+    String userId = (String) user.getProperty("userId");
+    EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
+    long currentUserPoints = (Long) userPoints.getProperty(userId);
+    long updatedUserPoints = currentUserPoints + POINTS_PER_ROUND;
+    userPoints.setProperty(userId, updatedUserPoints);
+    game.setProperty("userPoints", userPoints);
+    return game;
+  }
+
 }

--- a/src/main/java/com/google/songgame/data/GuessChecker.java
+++ b/src/main/java/com/google/songgame/data/GuessChecker.java
@@ -4,12 +4,13 @@ import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EmbeddedEntity;
 
 public final class GuessChecker {
-  private final static int POINTS_PER_ROUND = 100;
+  private static final int POINTS_PER_ROUND = 100;
 
-  public static boolean hasUserPreviouslyGuessed(Entity user, Entity game) {
+  public static boolean hasUserPreviouslyGuessedCorrect(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
     EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
-    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+    EmbeddedEntity userGuessStatuses =
+        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     boolean userGuessStatus = (Boolean) userGuessStatuses.getProperty(userId);
     return userGuessStatus;
   }
@@ -18,14 +19,15 @@ public final class GuessChecker {
     EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
     EmbeddedEntity currentVideo = (EmbeddedEntity) currentRound.getProperty("video");
     String videoTitle = (String) currentVideo.getProperty("title");
-    String guess = message.toLowerCase();
+    guess = guess.toLowerCase();
     return guess.equals(videoTitle);
   }
 
   public static Entity markUserGuessedCorrectly(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
-    EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentROund");
-    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+    EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
+    EmbeddedEntity userGuessStatuses =
+        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     userGuessStatuses.setProperty(userId, true);
     game.setProperty("currentRound", currentRound);
     return game;
@@ -33,12 +35,12 @@ public final class GuessChecker {
 
   public static Entity assignUserPoint(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
-    EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
+    EmbeddedEntity userPoints = (EmbeddedEntity) game.getProperty("userPoints");
     long currentUserPoints = (Long) userPoints.getProperty(userId);
+    // TODO: @salilnadkarni update to change points given depending on time answered
     long updatedUserPoints = currentUserPoints + POINTS_PER_ROUND;
     userPoints.setProperty(userId, updatedUserPoints);
     game.setProperty("userPoints", userPoints);
     return game;
   }
-
 }

--- a/src/main/java/com/google/songgame/data/GuessChecker.java
+++ b/src/main/java/com/google/songgame/data/GuessChecker.java
@@ -3,9 +3,16 @@ package com.google.songgame.data;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EmbeddedEntity;
 
+/**
+ * Contains various helper methods revolving around checking a users guess including checking whether a user has already correctly guessed, whether a guess is correct, and updating the game state if a user has guessed correctly
+ */
 public final class GuessChecker {
   private static final int POINTS_PER_ROUND = 100;
-
+  /**
+   * Checks if the user has already guessed correctly.
+   * 
+   * <p>Checks for the current round if the user has already guessed correctly and returns true or false
+   */
   public static boolean hasUserPreviouslyGuessedCorrect(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
     EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
@@ -15,6 +22,11 @@ public final class GuessChecker {
     return userGuessStatus;
   }
 
+  /**
+   * Checks if the given guess is correct.
+   * 
+   * <p>Checks if the guess is correct and matches the video title of the current round, ignoring case
+   */
   public static boolean isCorrectGuess(String guess, Entity game) {
     EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
     EmbeddedEntity currentVideo = (EmbeddedEntity) currentRound.getProperty("video");
@@ -23,6 +35,11 @@ public final class GuessChecker {
     return guess.equals(videoTitle);
   }
 
+  /**
+   * Updates the game state to indicate the user has correctly guessed
+   * 
+   * <p>Updates for the current round that the user has guessed correctly. Updates in the userGuessStatuses map stored in the currentRound entity of the game.
+   */
   public static Entity markUserGuessedCorrectly(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
     EmbeddedEntity currentRound = (EmbeddedEntity) game.getProperty("currentRound");
@@ -32,7 +49,12 @@ public final class GuessChecker {
     game.setProperty("currentRound", currentRound);
     return game;
   }
-
+  
+  /**
+   * Updates the game state by increasing the users points
+   * 
+   * <p>Updates for the given user the point total. Updates in the userPoints map.
+   */
   public static Entity assignUserPoints(Entity user, Entity game) {
     String userId = (String) user.getProperty("userId");
     EmbeddedEntity userPoints = (EmbeddedEntity) game.getProperty("userPoints");

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -34,13 +34,13 @@ import com.google.appengine.api.datastore.Query.FilterPredicate;
 @WebServlet("/chat")
 public final class ChatServlet extends HttpServlet {
 
-  private final static String APP_ID = "1024158";
-  private final static String CLIENT_KEY = "d15fbbe1c77552dc5097";
-  private final static String CLIENT_SECRET = "91fd789bf568ec43d2ee";
-  private final static String PUSHER_APPLICATION_NAME = "song-guessing-game";
-  private final static String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
-  private final static Type MESSAGE_TYPE = new TypeToken<Map<String, String>>(){}.getType();
-  private final static long POINTS_PER_ROUND = 100;
+  private static final String APP_ID = "1024158";
+  private static final String CLIENT_KEY = "d15fbbe1c77552dc5097";
+  private static final String CLIENT_SECRET = "91fd789bf568ec43d2ee";
+  private static final String PUSHER_APPLICATION_NAME = "song-guessing-game";
+  private static final String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
+  private static final Type MESSAGE_TYPE = new TypeToken<Map<String, String>>() {}.getType();
+  private static final long POINTS_PER_ROUND = 100;
   private Pusher pusher;
   private Gson gson;
   private DatastoreService datastore;
@@ -71,7 +71,7 @@ public final class ChatServlet extends HttpServlet {
     return jsonData;
   }
 
-  //TODO: @salilnadkarni modify when points stored in rooms
+  // TODO: @salilnadkarni modify when points stored in rooms
   private Map<String, String> createPusherChatResponse(Map<String, String> data) {
     Map<String, String> response = new HashMap<String, String>();
 
@@ -100,7 +100,7 @@ public final class ChatServlet extends HttpServlet {
     // TODO: @salilnadkarni add more robust way of finding current round
     Query gameQuery = new Query("Game").addSort("creationTime", SortDirection.DESCENDING);
     PreparedQuery result = datastore.prepare(gameQuery);
-    
+
     Entity currentGame = result.asList(FetchOptions.Builder.withLimit(1)).get(0);
     return currentGame;
   }
@@ -123,8 +123,7 @@ public final class ChatServlet extends HttpServlet {
   }
 
   private String getUsername(String userId) {
-    Filter userIdFilter =
-        new FilterPredicate("userId", FilterOperator.EQUAL, userId);
+    Filter userIdFilter = new FilterPredicate("userId", FilterOperator.EQUAL, userId);
     Query userQuery = new Query("User").setFilter(userIdFilter);
     PreparedQuery result = datastore.prepare(userQuery);
     Entity currentUser = result.asSingleEntity();
@@ -132,13 +131,16 @@ public final class ChatServlet extends HttpServlet {
   }
 
   private boolean checkIfUserPreviouslyGuessedCorrect(String userId, EmbeddedEntity currentRound) {
-    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+    EmbeddedEntity userGuessStatuses =
+        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     boolean userGuessStatus = (Boolean) userGuessStatuses.getProperty(userId);
     return userGuessStatus;
   }
 
-  private void markUserGuessedCorrectlyAndAddPoints(String userId, EmbeddedEntity currentRound, Entity currentGame) {
-    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+  private void markUserGuessedCorrectlyAndAddPoints(
+      String userId, EmbeddedEntity currentRound, Entity currentGame) {
+    EmbeddedEntity userGuessStatuses =
+        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     userGuessStatuses.setProperty(userId, true);
 
     EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
@@ -157,10 +159,10 @@ public final class ChatServlet extends HttpServlet {
     return message.equals(videoTitle);
   }
 
-  private void sendResponseToClient(HttpServletResponse response, String message) throws IOException {
+  private void sendResponseToClient(HttpServletResponse response, String message)
+      throws IOException {
     response.setContentType("application/json");
     String responseJsonString = gson.toJson(Collections.singletonMap("message", message));
     response.getWriter().println(responseJsonString);
   }
-
 }

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -30,6 +30,7 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
+import com.google.songgame.data.GuessChecker;
 
 @WebServlet("/chat")
 public final class ChatServlet extends HttpServlet {
@@ -71,24 +72,25 @@ public final class ChatServlet extends HttpServlet {
     return jsonData;
   }
 
-  // TODO: @salilnadkarni modify when points stored in rooms
   private Map<String, String> createPusherChatResponse(Map<String, String> data) {
     Map<String, String> response = new HashMap<String, String>();
 
-    Entity currentGame = getCurrentGame();
-    EmbeddedEntity currentRound = (EmbeddedEntity) currentGame.getProperty("currentRound");
-
-    // get user entity -> call guesschecker to see if prev correct && if correctly guessed
-
     String userId = data.get("userId");
-    String username = getUsername(userId);
+
+    Entity currentGame = getCurrentGame();
+    Entity currentUser = getUser(userId);
+
+    String username = (String) currentUser.getProperty("username");
     String message = data.get("message");
     String messageType = "guess";
 
-    if (checkIfUserPreviouslyGuessedCorrect(userId, currentRound)) {
+
+    if (GuessChecker.hasUserPreviouslyGuessed(currentUser, currentGame)) {
       messageType = "spectator";
-    } else if (isCorrectGuess(message, currentRound)) {
-      markUserGuessedCorrectlyAndAddPoints(userId, currentRound, currentGame);
+    } else if (GuessChecker.isCorrectGuess(message, currentGame)) {
+      currentGame = GuessChecker.markUserGuessedCorrectly(currentUser, currentGame);
+      currentGame = GuessChecker.assignUserPoint(currentUser, currentGame);
+      datastore.put(currentGame);
       messageType = "correct";
       message = "guessed correctly!";
     }
@@ -124,45 +126,12 @@ public final class ChatServlet extends HttpServlet {
     return userId;
   }
 
-  private String getUsername(String userId) {
+  private Entity getUser(String userId) {
     Filter userIdFilter = new FilterPredicate("userId", FilterOperator.EQUAL, userId);
     Query userQuery = new Query("User").setFilter(userIdFilter);
     PreparedQuery result = datastore.prepare(userQuery);
     Entity currentUser = result.asSingleEntity();
-    return (String) currentUser.getProperty("username");
-  }
-
-  private boolean checkIfUserPreviouslyGuessedCorrect(String userId, EmbeddedEntity currentRound) {
-    EmbeddedEntity userGuessStatuses =
-        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
-    boolean userGuessStatus = (Boolean) userGuessStatuses.getProperty(userId);
-    return userGuessStatus;
-  }
-
-  private void markUserGuessedCorrectlyAndAddPoints(
-      String userId, EmbeddedEntity currentRound, Entity currentGame) {
-    // Changes the users "guess status" to show they've guessed correctly
-    EmbeddedEntity userGuessStatuses =
-        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
-    userGuessStatuses.setProperty(userId, true);
-    
-    // Increases the users points by a fixed amount
-    EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
-    long currentUserPoints = (Long) userPoints.getProperty(userId);
-    long updatedUserPoints = currentUserPoints + POINTS_PER_ROUND;
-    userPoints.setProperty(userId, updatedUserPoints);
-    
-    // Update both changes in Datastore
-    currentGame.setProperty("currentRound", currentRound);
-    currentGame.setProperty("userPoints", userPoints);
-    datastore.put(currentGame);
-  }
-
-  private boolean isCorrectGuess(String message, EmbeddedEntity currentRound) {
-    EmbeddedEntity currentVideo = (EmbeddedEntity) currentRound.getProperty("video");
-    String videoTitle = (String) currentVideo.getProperty("title");
-    String guess = message.toLowerCase();
-    return guess.equals(videoTitle);
+    return currentUser;
   }
 
   private void sendResponseToClient(HttpServletResponse response, String message)

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -86,7 +86,7 @@ public final class ChatServlet extends HttpServlet {
     if (checkIfUserPreviouslyGuessedCorrect(userId, currentRound)) {
       messageType = "spectator";
     } else if (checkIfCorrectGuess(message, currentRound)) {
-      markUserGuessedCorrectly(userId, currentRound, currentGame);
+      markUserGuessedCorrectlyAndAddPoints(userId, currentRound, currentGame);
       messageType = "correct";
       message = "guessed correctly!";
     }
@@ -146,7 +146,7 @@ public final class ChatServlet extends HttpServlet {
     userPoints.setProperty(userId, currentUserPoints + POINTS_PER_ROUND);
 
     currentGame.setProperty("currentRound", currentRound);
-    currentGame.setPropert("userPoints", userPoints);
+    currentGame.setProperty("userPoints", userPoints);
     datastore.put(currentGame);
   }
 

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -143,7 +143,8 @@ public final class ChatServlet extends HttpServlet {
 
     EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
     long currentUserPoints = (Long) userPoints.getProperty(userId);
-    userPoints.setProperty(userId, currentUserPoints + POINTS_PER_ROUND);
+    long updatedUserPoints = currentUserPoints + POINTS_PER_ROUND;
+    userPoints.setProperty(userId, updatedUserPoints);
 
     currentGame.setProperty("currentRound", currentRound);
     currentGame.setProperty("userPoints", userPoints);

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -84,12 +84,11 @@ public final class ChatServlet extends HttpServlet {
     String message = data.get("message");
     String messageType = "guess";
 
-
     if (GuessChecker.hasUserPreviouslyGuessedCorrect(currentUser, currentGame)) {
       messageType = "spectator";
     } else if (GuessChecker.isCorrectGuess(message, currentGame)) {
       currentGame = GuessChecker.markUserGuessedCorrectly(currentUser, currentGame);
-      currentGame = GuessChecker.assignUserPoint(currentUser, currentGame);
+      currentGame = GuessChecker.assignUserPoints(currentUser, currentGame);
       datastore.put(currentGame);
       messageType = "correct";
       message = "guessed correctly!";

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -41,7 +41,6 @@ public final class ChatServlet extends HttpServlet {
   private static final String PUSHER_APPLICATION_NAME = "song-guessing-game";
   private static final String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
   private static final Type MESSAGE_TYPE = new TypeToken<Map<String, String>>() {}.getType();
-  private static final long POINTS_PER_ROUND = 100;
   private Pusher pusher;
   private Gson gson;
   private DatastoreService datastore;

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -85,7 +85,7 @@ public final class ChatServlet extends HttpServlet {
     String messageType = "guess";
 
 
-    if (GuessChecker.hasUserPreviouslyGuessed(currentUser, currentGame)) {
+    if (GuessChecker.hasUserPreviouslyGuessedCorrect(currentUser, currentGame)) {
       messageType = "spectator";
     } else if (GuessChecker.isCorrectGuess(message, currentGame)) {
       currentGame = GuessChecker.markUserGuessedCorrectly(currentUser, currentGame);

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -40,6 +40,7 @@ public final class ChatServlet extends HttpServlet {
   private final static String PUSHER_APPLICATION_NAME = "song-guessing-game";
   private final static String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
   private final static Type MESSAGE_TYPE = new TypeToken<Map<String, String>>(){}.getType();
+  private final static long POINTS_PER_ROUND = 100;
   private Pusher pusher;
   private Gson gson;
   private DatastoreService datastore;
@@ -136,10 +137,16 @@ public final class ChatServlet extends HttpServlet {
     return userGuessStatus;
   }
 
-  private void markUserGuessedCorrectly(String userId, EmbeddedEntity currentRound, Entity currentGame) {
+  private void markUserGuessedCorrectlyAndAddPoints(String userId, EmbeddedEntity currentRound, Entity currentGame) {
     EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     userGuessStatuses.setProperty(userId, true);
+
+    EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
+    long currentUserPoints = (Long) userPoints.getProperty(userId);
+    userPoints.setProperty(userId, currentUserPoints + POINTS_PER_ROUND);
+
     currentGame.setProperty("currentRound", currentRound);
+    currentGame.setPropert("userPoints", userPoints);
     datastore.put(currentGame);
   }
 

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -85,7 +85,7 @@ public final class ChatServlet extends HttpServlet {
 
     if (checkIfUserPreviouslyGuessedCorrect(userId, currentRound)) {
       messageType = "spectator";
-    } else if (checkIfCorrectGuess(message, currentRound)) {
+    } else if (isCorrectGuess(message, currentRound)) {
       markUserGuessedCorrectlyAndAddPoints(userId, currentRound, currentGame);
       messageType = "correct";
       message = "guessed correctly!";
@@ -139,21 +139,24 @@ public final class ChatServlet extends HttpServlet {
 
   private void markUserGuessedCorrectlyAndAddPoints(
       String userId, EmbeddedEntity currentRound, Entity currentGame) {
+    // Changes the users "guess status" to show they've guessed correctly
     EmbeddedEntity userGuessStatuses =
         (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     userGuessStatuses.setProperty(userId, true);
-
+    
+    // Increases the users points by a fixed amount
     EmbeddedEntity userPoints = (EmbeddedEntity) currentGame.getProperty("userPoints");
     long currentUserPoints = (Long) userPoints.getProperty(userId);
     long updatedUserPoints = currentUserPoints + POINTS_PER_ROUND;
     userPoints.setProperty(userId, updatedUserPoints);
-
+    
+    // Update both changes in Datastore
     currentGame.setProperty("currentRound", currentRound);
     currentGame.setProperty("userPoints", userPoints);
     datastore.put(currentGame);
   }
 
-  private boolean checkIfCorrectGuess(String message, EmbeddedEntity currentRound) {
+  private boolean isCorrectGuess(String message, EmbeddedEntity currentRound) {
     EmbeddedEntity currentVideo = (EmbeddedEntity) currentRound.getProperty("video");
     String videoTitle = (String) currentVideo.getProperty("title");
     return message.equals(videoTitle);

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -40,10 +40,7 @@ public final class ChatServlet extends HttpServlet {
   private static final String PUSHER_APPLICATION_NAME = "song-guessing-game";
   private static final String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
   private static final Type MESSAGE_TYPE = new TypeToken<Map<String, String>>() {}.getType();
-<<<<<<< HEAD
   private static final long POINTS_PER_ROUND = 100;
-=======
->>>>>>> master
   private Pusher pusher;
   private Gson gson;
   private DatastoreService datastore;
@@ -80,6 +77,8 @@ public final class ChatServlet extends HttpServlet {
 
     Entity currentGame = getCurrentGame();
     EmbeddedEntity currentRound = (EmbeddedEntity) currentGame.getProperty("currentRound");
+
+    // get user entity -> call guesschecker to see if prev correct && if correctly guessed
 
     String userId = data.get("userId");
     String username = getUsername(userId);

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -68,7 +68,7 @@ public final class GameServlet extends HttpServlet {
 
   private EmbeddedEntity getNewRound(Entity game) {
     ArrayList<String> playlist = (ArrayList<String>) game.getProperty("playlist");
-    EmbeddedEntity video = getVideoEntity(playlist);  
+    EmbeddedEntity video = getVideoEntity(playlist);
     EmbeddedEntity userGuessStatuses = createUserGuessStatuses();
 
     EmbeddedEntity currentRound = new EmbeddedEntity();
@@ -87,13 +87,13 @@ public final class GameServlet extends HttpServlet {
     EmbeddedEntity videoEntity = new EmbeddedEntity();
     videoEntity.setProperty("videoId", videoId);
     videoEntity.setProperty("title", videoTitle);
-    
+
     return videoEntity;
   }
 
   private EmbeddedEntity createUserGuessStatuses() {
     EmbeddedEntity userGuessStatuses = new EmbeddedEntity();
-    //TODO: @salilnadkarni, add more specific query to only get users with correct roomId
+    // TODO: @salilnadkarni, add more specific query to only get users with correct roomId
     Query query = new Query("User");
     PreparedQuery results = datastore.prepare(query);
 
@@ -141,7 +141,7 @@ public final class GameServlet extends HttpServlet {
 
   private EmbeddedEntity createUserPoints() {
     EmbeddedEntity userPoints = new EmbeddedEntity();
-    //TODO: @salilnadkarni, add more specific query to only get users with correct roomId
+    // TODO: @salilnadkarni, add more specific query to only get users with correct roomId
     Query query = new Query("User");
     PreparedQuery results = datastore.prepare(query);
 
@@ -152,5 +152,4 @@ public final class GameServlet extends HttpServlet {
 
     return userPoints;
   }
-
 }

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -128,13 +128,29 @@ public final class GameServlet extends HttpServlet {
     YoutubeParser parser = new YoutubeParser();
     ArrayList<String> playlistVideoIds = parser.getPlaylistVideoIds(playlistUrl);
     long creationTime = System.currentTimeMillis();
+    EmbeddedEntity userPoints = createUserPoints();
 
     Entity gameEntity = new Entity("Game");
     gameEntity.setProperty("playlist", playlistVideoIds);
     gameEntity.setProperty("creationTime", creationTime);
+    gameEntity.setProperty("userPoints", userPoints);
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(gameEntity);
+  }
+
+  private EmbeddedEntity createUserPoints() {
+    EmbeddedEntity userPoints = new EmbeddedEntity();
+    //TODO: @salilnadkarni, add more specific query to only get users with correct roomId
+    Query query = new Query("User");
+    PreparedQuery results = datastore.prepare(query);
+
+    for (Entity user : results.asIterable()) {
+      String userId = (String) user.getProperty("userId");
+      userPoints.setProperty(userId, 0);
+    }
+
+    return userPoints;
   }
 
 }

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -148,7 +148,7 @@ public final class GameServlet extends HttpServlet {
 
     for (Entity user : results.asIterable()) {
       String userId = (String) user.getProperty("userId");
-      userPoints.setProperty(userId, 0);
+      userPoints.setProperty(userId, 0L);
     }
 
     return userPoints;

--- a/src/test/java/com/google/songgame/GuessCheckerTest.java
+++ b/src/test/java/com/google/songgame/GuessCheckerTest.java
@@ -65,27 +65,25 @@ public final class GuessCheckerTest {
     Entity willGuessUser = createBob();
     Entity currentGame = createGame();
 
-    int billPoint =
-        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("123");
-    int bobPoint =
-        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("789");
+    long billPoint =
+        (Long) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("123");
+    long bobPoint =
+        (Long) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("789");
 
     Assert.assertEquals(0, billPoint);
     Assert.assertEquals(0, bobPoint);
 
     currentGame = GuessChecker.assignUserPoints(willGuessUser, currentGame);
 
-    billPoint =
-        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("123");
-    bobPoint =
-        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("789");
+    billPoint = (Long) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("123");
+    bobPoint = (Long) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("789");
 
-    Assert.assertEquals(0, billPoint);
-    Assert.assertEquals(100, bobPoint);
+    Assert.assertEquals(0L, billPoint);
+    Assert.assertEquals(100L, bobPoint);
   }
 
   @Test
-  public void checkIsCorrectGuessCapitalization() {
+  public void checkIsCorrectGuessCasing() {
     Entity currentGame = createGame();
     Assert.assertEquals(true, GuessChecker.isCorrectGuess("hey jude", currentGame));
     Assert.assertEquals(true, GuessChecker.isCorrectGuess("Hey Jude", currentGame));
@@ -118,9 +116,9 @@ public final class GuessCheckerTest {
     Entity currentGame = new Entity("Game");
 
     EmbeddedEntity userPoints = new EmbeddedEntity();
-    userPoints.setProperty("123", 0);
-    userPoints.setProperty("567", 100);
-    userPoints.setProperty("789", 0);
+    userPoints.setProperty("123", 0L);
+    userPoints.setProperty("567", 100L);
+    userPoints.setProperty("789", 0L);
     currentGame.setProperty("userPoints", userPoints);
 
     EmbeddedEntity currentRound = new EmbeddedEntity();
@@ -130,11 +128,11 @@ public final class GuessCheckerTest {
     currentVideo.setProperty("videoId", "abc");
     currentRound.setProperty("video", currentVideo);
 
-    EmbeddedEntity userGuessStatus = new EmbeddedEntity();
-    userGuessStatus.setProperty("123", false);
-    userGuessStatus.setProperty("567", true);
-    userGuessStatus.setProperty("789", false);
-    currentRound.setProperty("userGuessStatus", userGuessStatus);
+    EmbeddedEntity userGuessStatuses = new EmbeddedEntity();
+    userGuessStatuses.setProperty("123", false);
+    userGuessStatuses.setProperty("567", true);
+    userGuessStatuses.setProperty("789", false);
+    currentRound.setProperty("userGuessStatuses", userGuessStatuses);
 
     currentGame.setProperty("currentRound", currentRound);
 

--- a/src/test/java/com/google/songgame/GuessCheckerTest.java
+++ b/src/test/java/com/google/songgame/GuessCheckerTest.java
@@ -1,0 +1,143 @@
+package com.google.songgame.data;
+
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.EmbeddedEntity;
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class GuessCheckerTest {
+
+  private final LocalServiceTestHelper helper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+
+  @Before
+  public void setUp() {
+    helper.setUp();
+  }
+
+  @After
+  public void tearDown() {
+    helper.tearDown();
+  }
+
+  @Test
+  public void checkHasUserPreviouslyGuessed() {
+    Entity notGuessedUser = createBill();
+    Entity alreadyGuessedUser = createJane();
+    Entity currentGame = createGame();
+
+    Assert.assertEquals(
+        false, GuessChecker.hasUserPreviouslyGuessedCorrect(notGuessedUser, currentGame));
+    Assert.assertEquals(
+        true, GuessChecker.hasUserPreviouslyGuessedCorrect(alreadyGuessedUser, currentGame));
+  }
+
+  @Test
+  public void checkMarkUserGuessedCorrectly() {
+    Entity notGuessedUser = createBill();
+    Entity willGuessUser = createBob();
+    Entity currentGame = createGame();
+
+    Assert.assertEquals(
+        false, GuessChecker.hasUserPreviouslyGuessedCorrect(notGuessedUser, currentGame));
+    Assert.assertEquals(
+        false, GuessChecker.hasUserPreviouslyGuessedCorrect(willGuessUser, currentGame));
+
+    currentGame = GuessChecker.markUserGuessedCorrectly(willGuessUser, currentGame);
+
+    Assert.assertEquals(
+        false, GuessChecker.hasUserPreviouslyGuessedCorrect(notGuessedUser, currentGame));
+    Assert.assertEquals(
+        true, GuessChecker.hasUserPreviouslyGuessedCorrect(willGuessUser, currentGame));
+  }
+
+  @Test
+  public void checkAssignUserPoints() {
+    Entity notGuessedUser = createBill();
+    Entity willGuessUser = createBob();
+    Entity currentGame = createGame();
+
+    int billPoint =
+        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("123");
+    int bobPoint =
+        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("789");
+
+    Assert.assertEquals(0, billPoint);
+    Assert.assertEquals(0, bobPoint);
+
+    currentGame = GuessChecker.assignUserPoints(willGuessUser, currentGame);
+
+    billPoint =
+        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("123");
+    bobPoint =
+        (Integer) ((EmbeddedEntity) currentGame.getProperty("userPoints")).getProperty("789");
+
+    Assert.assertEquals(0, billPoint);
+    Assert.assertEquals(100, bobPoint);
+  }
+
+  @Test
+  public void checkIsCorrectGuessCapitalization() {
+    Entity currentGame = createGame();
+    Assert.assertEquals(true, GuessChecker.isCorrectGuess("hey jude", currentGame));
+    Assert.assertEquals(true, GuessChecker.isCorrectGuess("Hey Jude", currentGame));
+    Assert.assertEquals(true, GuessChecker.isCorrectGuess("hEy JUde", currentGame));
+    Assert.assertEquals(false, GuessChecker.isCorrectGuess("hey jade", currentGame));
+  }
+
+  private Entity createBill() {
+    Entity bill = new Entity("User");
+    bill.setProperty("userId", "123");
+    bill.setProperty("username", "Bill");
+    return bill;
+  }
+
+  private Entity createJane() {
+    Entity bill = new Entity("User");
+    bill.setProperty("userId", "567");
+    bill.setProperty("username", "Jane");
+    return bill;
+  }
+
+  private Entity createBob() {
+    Entity bob = new Entity("User");
+    bob.setProperty("userId", "789");
+    bob.setProperty("username", "Bob");
+    return bob;
+  }
+
+  private Entity createGame() {
+    Entity currentGame = new Entity("Game");
+
+    EmbeddedEntity userPoints = new EmbeddedEntity();
+    userPoints.setProperty("123", 0);
+    userPoints.setProperty("567", 100);
+    userPoints.setProperty("789", 0);
+    currentGame.setProperty("userPoints", userPoints);
+
+    EmbeddedEntity currentRound = new EmbeddedEntity();
+
+    EmbeddedEntity currentVideo = new EmbeddedEntity();
+    currentVideo.setProperty("title", "hey jude");
+    currentVideo.setProperty("videoId", "abc");
+    currentRound.setProperty("video", currentVideo);
+
+    EmbeddedEntity userGuessStatus = new EmbeddedEntity();
+    userGuessStatus.setProperty("123", false);
+    userGuessStatus.setProperty("567", true);
+    userGuessStatus.setProperty("789", false);
+    currentRound.setProperty("userGuessStatus", userGuessStatus);
+
+    currentGame.setProperty("currentRound", currentRound);
+
+    return currentGame;
+  }
+}


### PR DESCRIPTION
Add a points system in the Datastore to store a running total of points between rounds. Ran Java formatter on both files.

In **GameServlet**:
* add a new EmbeddedEntity field, `userPoints` to the Game Entity, acting as a Map between userId and point total
* create a function `createUserPoints` which instantiates a Map of User to points (starting at 0)
* TODO: update `createUserPoints` to add only users in the current "room" to the `userPoints` map, not all users

In **ChatServlet**
* Update `markUserGuessedCorrectly` to `markUserGuessedCorrectlyAndUpdatePoints` (so it handles updating points as well)
* Add a new private static constant `POINTS_PER_ROUND` to be used to determine how many points a user gets per round if they guess correctly (currently a hundred)

Video showing point values updating in Datastore (https://screencast.googleplex.com/cast/NTI1MjEwNTgxODM0MTM3NnxjNDg2MzM0ZS1kZA)