### PR TITLE
Improve answer checking for chat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
       <artifactId>pusher-http-java</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/songgame/data/TitleFormatter.java
+++ b/src/main/java/com/google/songgame/data/TitleFormatter.java
@@ -9,6 +9,42 @@ import java.util.Arrays;
 
 public final class TitleFormatter {
 
+  public static String formatVideoTitle(String title) {
+    String result = title.toLowerCase();
+
+    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
+    Matcher matcher = pattern.matcher(result);
+    result = matcher.replaceAll(replaceTargetGroups);
+
+    pattern = Pattern.compile("\\[([^\\]]+)\\]");
+    matcher = pattern.matcher(result);
+    result = matcher.replaceAll((MatchResult matchResult) -> "");
+
+    result = removeArtistPrefix(result);
+    result = removeExcessWhiteSpace(result);
+
+    return result;
+  }
+
+  private static boolean checkIfStringInArrayOfStrings(String s) {
+    ArrayList<String> targetWords =
+        new ArrayList<String>(
+            Arrays.asList(
+                "feat",
+                "remix",
+                "ft",
+                "music video",
+                "official video",
+                "lyric video",
+                "official audio"));
+    for (String targetWord : targetWords) {
+      if (s.contains(targetWord)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static final Function<MatchResult, String> replaceTargetGroups =
       (MatchResult matchResult) -> {
         String matchResultString = matchResult.group(1);
@@ -19,24 +55,17 @@ public final class TitleFormatter {
         }
       };
 
-  private static boolean checkIfStringInArrayOfStrings(String s) {
-    ArrayList<String> targetWords =
-        new ArrayList<String>(
-            Arrays.asList("feat", "remix", "ft", "music video", "official video", "lyric video"));
-    for (String targetWord : targetWords) {
-      if (s.contains(targetWord)) {
-        return true;
-      }
+  private static String removeArtistPrefix(String input) {
+    if (!input.contains("-")) {
+      return input;
     }
-    return false;
+    String result = input.split("-")[1];
+    return result;
   }
 
-  public static String formatVideoTitle(String title) {
-    title = title.toLowerCase();
-    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
-    Matcher matcher = pattern.matcher(title);
-    String result = matcher.replaceAll(replaceTargetGroups);
-    System.out.println(result);
+  private static String removeExcessWhiteSpace(String input) {
+    String result = input.trim();
+    result = result.replaceAll(" +", " ");
     return result;
   }
 }

--- a/src/main/java/com/google/songgame/data/TitleFormatter.java
+++ b/src/main/java/com/google/songgame/data/TitleFormatter.java
@@ -5,23 +5,26 @@ import java.util.regex.Matcher;
 import java.util.regex.MatchResult;
 import java.util.function.Function;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public final class TitleFormatter {
-  private static final ArrayList<String> targetWords = new ArrayList<String>({
-    "feat", "remix", "ft", "music video", "official video", "lyric video"
-  });
-  private static final Function<MatchResult,String> replaceTargetGroups = (MatchResult matchResult) -> {
-    String matchResultString = matchResult.group(1);
-    if (checkIfStringInArrayOfStrings(targetWords, matchResultString)) {
-      return "";
-    } else {
-      return "(" + matchResultString + ")";
-    }
-  };
 
-  private boolean checkIfStringInArrayOfStrings(ArrayList<String> possibleStrings, String s) {
-    for (String possibleString : possibleStrings) {
-      if (s.contains(possibleString)) {
+  private static final Function<MatchResult, String> replaceTargetGroups =
+      (MatchResult matchResult) -> {
+        String matchResultString = matchResult.group(1);
+        if (checkIfStringInArrayOfStrings(matchResultString)) {
+          return "";
+        } else {
+          return "(" + matchResultString + ")";
+        }
+      };
+
+  private static boolean checkIfStringInArrayOfStrings(String s) {
+    ArrayList<String> targetWords =
+        new ArrayList<String>(
+            Arrays.asList("feat", "remix", "ft", "music video", "official video", "lyric video"));
+    for (String targetWord : targetWords) {
+      if (s.contains(targetWord)) {
         return true;
       }
     }
@@ -31,7 +34,7 @@ public final class TitleFormatter {
   public static String formatVideoTitle(String title) {
     title = title.toLowerCase();
     Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
-    Matcher matcher = pattern.matcher(title);   
+    Matcher matcher = pattern.matcher(title);
     String result = matcher.replaceAll(replaceTargetGroups);
     System.out.println(result);
     return result;

--- a/src/main/java/com/google/songgame/data/TitleFormatter.java
+++ b/src/main/java/com/google/songgame/data/TitleFormatter.java
@@ -1,0 +1,39 @@
+package com.google.songgame.data;
+
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.regex.MatchResult;
+import java.util.function.Function;
+import java.util.ArrayList;
+
+public final class TitleFormatter {
+  private static final ArrayList<String> targetWords = new ArrayList<String>({
+    "feat", "remix", "ft", "music video", "official video", "lyric video"
+  });
+  private static final Function<MatchResult,String> replaceTargetGroups = (MatchResult matchResult) -> {
+    String matchResultString = matchResult.group(1);
+    if (checkIfStringInArrayOfStrings(targetWords, matchResultString)) {
+      return "";
+    } else {
+      return "(" + matchResultString + ")";
+    }
+  };
+
+  private boolean checkIfStringInArrayOfStrings(ArrayList<String> possibleStrings, String s) {
+    for (String possibleString : possibleStrings) {
+      if (s.contains(possibleString)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static String formatVideoTitle(String title) {
+    title = title.toLowerCase();
+    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
+    Matcher matcher = pattern.matcher(title);   
+    String result = matcher.replaceAll(replaceTargetGroups);
+    System.out.println(result);
+    return result;
+  }
+}

--- a/src/main/java/com/google/songgame/data/TitleFormatter.java
+++ b/src/main/java/com/google/songgame/data/TitleFormatter.java
@@ -6,8 +6,16 @@ import java.util.regex.MatchResult;
 import java.util.ArrayList;
 import java.util.Arrays;
 
+/** Helper class to standardize Youtube Music Video titles. */
 public final class TitleFormatter {
-
+  /**
+   * Takes in Youtube Music Video title and standardizes it.
+   *
+   * <p>Standarizes it to contain only the song title in lowercase with no excess white space.
+   * Removes artists, common tags (eg. official audio, music video, remix, etc).
+   *
+   * <p>Example: 'YG - Swag (Official Music Video)' converted to 'swag'
+   */
   public static String formatVideoTitle(String title) {
     String result = title.toLowerCase();
     result = removeInvalidParenthesesGroups(result);

--- a/src/main/java/com/google/songgame/data/TitleFormatter.java
+++ b/src/main/java/com/google/songgame/data/TitleFormatter.java
@@ -46,12 +46,7 @@ public final class TitleFormatter {
                 "official video",
                 "lyric video",
                 "official audio"));
-    for (String invalidWord : invalidWords) {
-      if (s.contains(invalidWord)) {
-        return true;
-      }
-    }
-    return false;
+    return invalidWords.stream().anyMatch(word -> s.contains(word));
   }
 
   private static String removeAllSquareBracketGroups(String s) {

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -34,12 +34,12 @@ import com.google.appengine.api.datastore.Query.FilterPredicate;
 @WebServlet("/chat")
 public final class ChatServlet extends HttpServlet {
 
-  private final static String APP_ID = "1024158";
-  private final static String CLIENT_KEY = "d15fbbe1c77552dc5097";
-  private final static String CLIENT_SECRET = "91fd789bf568ec43d2ee";
-  private final static String PUSHER_APPLICATION_NAME = "song-guessing-game";
-  private final static String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
-  private final static Type MESSAGE_TYPE = new TypeToken<Map<String, String>>(){}.getType();
+  private static final String APP_ID = "1024158";
+  private static final String CLIENT_KEY = "d15fbbe1c77552dc5097";
+  private static final String CLIENT_SECRET = "91fd789bf568ec43d2ee";
+  private static final String PUSHER_APPLICATION_NAME = "song-guessing-game";
+  private static final String PUSHER_CHAT_CHANNEL_NAME = "chat-update";
+  private static final Type MESSAGE_TYPE = new TypeToken<Map<String, String>>() {}.getType();
   private Pusher pusher;
   private Gson gson;
   private DatastoreService datastore;
@@ -70,7 +70,7 @@ public final class ChatServlet extends HttpServlet {
     return jsonData;
   }
 
-  //TODO: @salilnadkarni modify when points stored in rooms
+  // TODO: @salilnadkarni modify when points stored in rooms
   private Map<String, String> createPusherChatResponse(Map<String, String> data) {
     Map<String, String> response = new HashMap<String, String>();
 
@@ -99,7 +99,7 @@ public final class ChatServlet extends HttpServlet {
     // TODO: @salilnadkarni add more robust way of finding current round
     Query gameQuery = new Query("Game").addSort("creationTime", SortDirection.DESCENDING);
     PreparedQuery result = datastore.prepare(gameQuery);
-    
+
     Entity currentGame = result.asList(FetchOptions.Builder.withLimit(1)).get(0);
     return currentGame;
   }
@@ -122,8 +122,7 @@ public final class ChatServlet extends HttpServlet {
   }
 
   private String getUsername(String userId) {
-    Filter userIdFilter =
-        new FilterPredicate("userId", FilterOperator.EQUAL, userId);
+    Filter userIdFilter = new FilterPredicate("userId", FilterOperator.EQUAL, userId);
     Query userQuery = new Query("User").setFilter(userIdFilter);
     PreparedQuery result = datastore.prepare(userQuery);
     Entity currentUser = result.asSingleEntity();
@@ -131,13 +130,16 @@ public final class ChatServlet extends HttpServlet {
   }
 
   private boolean checkIfUserPreviouslyGuessedCorrect(String userId, EmbeddedEntity currentRound) {
-    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+    EmbeddedEntity userGuessStatuses =
+        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     boolean userGuessStatus = (Boolean) userGuessStatuses.getProperty(userId);
     return userGuessStatus;
   }
 
-  private void markUserGuessedCorrectly(String userId, EmbeddedEntity currentRound, Entity currentGame) {
-    EmbeddedEntity userGuessStatuses = (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
+  private void markUserGuessedCorrectly(
+      String userId, EmbeddedEntity currentRound, Entity currentGame) {
+    EmbeddedEntity userGuessStatuses =
+        (EmbeddedEntity) currentRound.getProperty("userGuessStatuses");
     userGuessStatuses.setProperty(userId, true);
     currentGame.setProperty("currentRound", currentRound);
     datastore.put(currentGame);
@@ -146,13 +148,14 @@ public final class ChatServlet extends HttpServlet {
   private boolean checkIfCorrectGuess(String message, EmbeddedEntity currentRound) {
     EmbeddedEntity currentVideo = (EmbeddedEntity) currentRound.getProperty("video");
     String videoTitle = (String) currentVideo.getProperty("title");
-    return message.equals(videoTitle);
+    String guess = message.toLowerCase();
+    return guess.equals(videoTitle);
   }
 
-  private void sendResponseToClient(HttpServletResponse response, String message) throws IOException {
+  private void sendResponseToClient(HttpServletResponse response, String message)
+      throws IOException {
     response.setContentType("application/json");
     String responseJsonString = gson.toJson(Collections.singletonMap("message", message));
     response.getWriter().println(responseJsonString);
   }
-
 }

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -20,6 +20,9 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.FetchOptions;
 import javax.servlet.http.Cookie;
 import java.lang.reflect.Type;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.regex.MatchResult;
 import com.google.gson.reflect.TypeToken;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -30,6 +33,7 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
+import java.util.Function;
 
 @WebServlet("/chat")
 public final class ChatServlet extends HttpServlet {
@@ -146,7 +150,34 @@ public final class ChatServlet extends HttpServlet {
     
     Entity currentVideo = result.asList(FetchOptions.Builder.withLimit(1)).get(0);
     String videoTitle = (String) currentVideo.getProperty("title");
+    System.out.println(checkGuessWithRegex(message));
     return message.equals(videoTitle);
+  }
+
+  private String checkGuessWithRegex(String guess) {
+    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
+    Matcher matcher = pattern.matcher(guess);
+
+    Function<MatchResult,String> thingy = (MatchResult mr) -> {
+      String mrs = mr.group(1);
+      if (mrs.find("feat")) {
+        return "";
+      } else {
+        return mrs;
+      }
+    };
+    
+    String result = matcher.replaceAll(thingy);
+    return result;
+    // if (matcher.find()) {
+    //   String currentGroup = matcher.group();
+    //   if (currentGroup.find("feat")) {
+    //     guess.remove(currentGroup.start(), currentGroup.end());
+    //   } else if (currentGroup.find("ft")) {
+    //     guess.remove(currentGroup.start(), currentGroup.end());
+    //   }
+    // }
+    // return guess;
   }
 
   private void sendResponseToClient(HttpServletResponse response, String message) throws IOException {

--- a/src/main/java/com/google/songgame/servlets/ChatServlet.java
+++ b/src/main/java/com/google/songgame/servlets/ChatServlet.java
@@ -20,9 +20,6 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.FetchOptions;
 import javax.servlet.http.Cookie;
 import java.lang.reflect.Type;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
-import java.util.regex.MatchResult;
 import com.google.gson.reflect.TypeToken;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
@@ -33,7 +30,6 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.Filter;
 import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
-import java.util.Function;
 
 @WebServlet("/chat")
 public final class ChatServlet extends HttpServlet {
@@ -150,34 +146,7 @@ public final class ChatServlet extends HttpServlet {
     
     Entity currentVideo = result.asList(FetchOptions.Builder.withLimit(1)).get(0);
     String videoTitle = (String) currentVideo.getProperty("title");
-    System.out.println(checkGuessWithRegex(message));
     return message.equals(videoTitle);
-  }
-
-  private String checkGuessWithRegex(String guess) {
-    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
-    Matcher matcher = pattern.matcher(guess);
-
-    Function<MatchResult,String> thingy = (MatchResult mr) -> {
-      String mrs = mr.group(1);
-      if (mrs.find("feat")) {
-        return "";
-      } else {
-        return mrs;
-      }
-    };
-    
-    String result = matcher.replaceAll(thingy);
-    return result;
-    // if (matcher.find()) {
-    //   String currentGroup = matcher.group();
-    //   if (currentGroup.find("feat")) {
-    //     guess.remove(currentGroup.start(), currentGroup.end());
-    //   } else if (currentGroup.find("ft")) {
-    //     guess.remove(currentGroup.start(), currentGroup.end());
-    //   }
-    // }
-    // return guess;
   }
 
   private void sendResponseToClient(HttpServletResponse response, String message) throws IOException {

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -34,11 +34,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.api.client.json.gson.GsonFactory;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
-import java.util.regex.MatchResult;
-import java.util.function.Function;
-
 
 @WebServlet("/game")
 public final class GameServlet extends HttpServlet {
@@ -141,24 +136,5 @@ public final class GameServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(gameEntity);
   }
-  
-  private String formatVideoTitle(String title) {
-    title = title.toLowerCase();
-    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
-    Matcher matcher = pattern.matcher(title);
 
-    // Function object, replaces all "groups" which contain "feat", "remix", or "ft"
-    Function<MatchResult,String> replaceTargetGroups = (MatchResult mr) -> {
-      String mrs = mr.group(1);
-      if (mrs.contains("feat") || mrs.contains("remix") || mrs.contains("ft") || mrs.contains("official video") || mrs.contains("official music video")) {
-        return "";
-      } else {
-        return "(" + mrs + ")";
-      }
-    };
-    
-    String result = matcher.replaceAll(replaceTargetGroups);
-    System.out.println(result);
-    return result;
-  }
 }

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -86,7 +86,6 @@ public final class GameServlet extends HttpServlet {
     String unformattedVideoTitle = video.getSnippet().getTitle();
     TitleFormatter titleFormatter = new TitleFormatter();
     String videoTitle = titleFormatter.formatVideoTitle(unformattedVideoTitle);
-    System.out.println(videoTitle);
     EmbeddedEntity videoEntity = new EmbeddedEntity();
     videoEntity.setProperty("videoId", videoId);
     videoEntity.setProperty("title", videoTitle);

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -84,8 +84,7 @@ public final class GameServlet extends HttpServlet {
     Video video = parser.getRandomVideoFromPlaylist(playlist);
     String videoId = video.getId();
     String unformattedVideoTitle = video.getSnippet().getTitle();
-    TitleFormatter titleFormatter = new TitleFormatter();
-    String videoTitle = titleFormatter.formatVideoTitle(unformattedVideoTitle);
+    String videoTitle = TitleFormatter.formatVideoTitle(unformattedVideoTitle);
     EmbeddedEntity videoEntity = new EmbeddedEntity();
     videoEntity.setProperty("videoId", videoId);
     videoEntity.setProperty("title", videoTitle);

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -20,6 +20,7 @@ import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.appengine.api.datastore.FetchOptions;
 import com.google.appengine.api.datastore.Text;
 import com.google.gson.Gson;
+import com.google.songgame.data.TitleFormatter;
 import com.google.songgame.data.YoutubeParser;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -68,7 +69,7 @@ public final class GameServlet extends HttpServlet {
 
   private EmbeddedEntity getNewRound(Entity game) {
     ArrayList<String> playlist = (ArrayList<String>) game.getProperty("playlist");
-    EmbeddedEntity video = getVideoEntity(playlist);  
+    EmbeddedEntity video = getVideoEntity(playlist);
     EmbeddedEntity userGuessStatuses = createUserGuessStatuses();
 
     EmbeddedEntity currentRound = new EmbeddedEntity();
@@ -82,18 +83,20 @@ public final class GameServlet extends HttpServlet {
     YoutubeParser parser = new YoutubeParser();
     Video video = parser.getRandomVideoFromPlaylist(playlist);
     String videoId = video.getId();
-    String videoTitle = video.getSnippet().getTitle();
-
+    String unformattedVideoTitle = video.getSnippet().getTitle();
+    TitleFormatter titleFormatter = new TitleFormatter();
+    String videoTitle = titleFormatter.formatTitle(unformattedVideoTitle);
+    System.out.println(videoTitle);
     EmbeddedEntity videoEntity = new EmbeddedEntity();
     videoEntity.setProperty("videoId", videoId);
     videoEntity.setProperty("title", videoTitle);
-    
+
     return videoEntity;
   }
 
   private EmbeddedEntity createUserGuessStatuses() {
     EmbeddedEntity userGuessStatuses = new EmbeddedEntity();
-    //TODO: @salilnadkarni, add more specific query to only get users with correct roomId
+    // TODO: @salilnadkarni, add more specific query to only get users with correct roomId
     Query query = new Query("User");
     PreparedQuery results = datastore.prepare(query);
 
@@ -136,5 +139,4 @@ public final class GameServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(gameEntity);
   }
-
 }

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -32,6 +32,11 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import com.google.api.client.json.gson.GsonFactory;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
+import java.util.regex.MatchResult;
+import java.util.function.Function;
+
 
 @WebServlet("/game")
 public final class GameServlet extends HttpServlet {
@@ -247,7 +252,8 @@ public final class GameServlet extends HttpServlet {
    * Set video information in Datastore
    */
   private void setVideoInfo(Video video) {
-    String videoTitle = video.getSnippet().getTitle();
+    String unformattedVideoTitle = video.getSnippet().getTitle();
+    String videoTitle = formatVideoTitle(unformattedVideoTitle);
     long fetchTime = System.currentTimeMillis();
     String videoId = video.getId();
     
@@ -257,6 +263,26 @@ public final class GameServlet extends HttpServlet {
     videoEntity.setProperty("videoId", videoId);
     
     datastore.put(videoEntity);
+  }
+
+  private String formatVideoTitle(String title) {
+    title = title.toLowerCase();
+    Pattern pattern = Pattern.compile("\\(([^\\)]+)\\)");
+    Matcher matcher = pattern.matcher(title);
+
+    // Function object, replaces all "groups" which contain "feat", "remix", or "ft"
+    Function<MatchResult,String> replaceTargetGroups = (MatchResult mr) -> {
+      String mrs = mr.group(1);
+      if (mrs.contains("feat") || mrs.contains("remix") || mrs.contains("ft") || mrs.contains("official video") || mrs.contains("official music video")) {
+        return "";
+      } else {
+        return "(" + mrs + ")";
+      }
+    };
+    
+    String result = matcher.replaceAll(replaceTargetGroups);
+    System.out.println(result);
+    return result;
   }
 
 }

--- a/src/main/java/com/google/songgame/servlets/GameServlet.java
+++ b/src/main/java/com/google/songgame/servlets/GameServlet.java
@@ -85,7 +85,7 @@ public final class GameServlet extends HttpServlet {
     String videoId = video.getId();
     String unformattedVideoTitle = video.getSnippet().getTitle();
     TitleFormatter titleFormatter = new TitleFormatter();
-    String videoTitle = titleFormatter.formatTitle(unformattedVideoTitle);
+    String videoTitle = titleFormatter.formatVideoTitle(unformattedVideoTitle);
     System.out.println(videoTitle);
     EmbeddedEntity videoEntity = new EmbeddedEntity();
     videoEntity.setProperty("videoId", videoId);

--- a/src/test/com/google/songgame/data/TitleFormatterTest.java
+++ b/src/test/com/google/songgame/data/TitleFormatterTest.java
@@ -1,0 +1,80 @@
+package com.google.songgame;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/*
+  https://music.youtube.com/playlist?list=RDCLAK5uy_kmPRjHDECIcuVwnKsx2Ng7fyNgFKWNJFs
+
+*/
+
+@RunWith(JUnit4.class)
+public final class TitleFormatterTest {
+  @Test
+  public void bigboitest() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+    String testString = "Life is Good (Official Music Video) (feat. Drake)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "life is good");
+
+    testString = "Marvins Room";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "marvins room");
+
+    testString = "Sativa (ft. Swae Lee)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "sativa");
+
+    testString = "Get You (feat. Kali Uchis)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "get you");
+
+    testString = "Promises (feat. Namiko, Miyagi & Miyagi & Namiko)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "promises");
+
+    testString = "WHATS POPPIN [Remix] (feat. DaBaby, Tory Lanez & Lil Wayne";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "whats poppin");
+
+    testString = "Juice WRLD ft. Marshmello - Come & Go (Official Audio)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
+
+    testString = "Savage (Remix) (feat. Beyoncé)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
+
+    testString = "BLACK PARADE";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "black parade");
+
+    testString = "Roses (Imanbek Remix) [Latino Gang]";
+
+    testString = "Rod Wave - Girl Of My Dreams (Official Music Video)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "girl of my dreams");
+
+    testString = "ily (i love you baby) (feat. Emilee)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "ily (i love you baby)");
+
+    testString = "death bed (coffee for your head)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "death bed (coffee for your head)");
+
+    testString = "Gucci Mane - Both Sides feat. Lil Baby";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
+
+    testString = "YG - Swag (Official Music Video)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "swag");
+
+    testString = "Chase B & Don Toliver - Cafeteria (feat. Gunna) (Official Video)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "cafeteria");
+    
+    testString = "NBA YoungBoy - ALL IN";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "all in");
+    
+    testString = "King Von - Why He Told (Official Video)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "why he told");
+
+    testString = "Tattoo (Remix)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "tattoo");
+
+    testString = "Djadja [Remix] (feat. Afro B)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "djadja");
+
+    testString = "La Jeepeta Remix (Lyric Video)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "la jeepeta");
+  }
+}

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -12,16 +12,23 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public final class TitleFormatterTest {
-  @Test
-  public void bigboitest() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-    String testString = "Life is Good (Official Music Video) (feat. Drake)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "life is good");
 
-    testString = "Marvins Room";
+  @Test
+  public void simpleCapitalization() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+
+    String testString = "Marvins Room";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "marvins room");
 
-    testString = "Sativa (ft. Swae Lee)";
+    testString = "BLACK PARADE";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "black parade");
+  }
+
+  @Test
+  public void removeOneGroup() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+
+    String testString = "Sativa (ft. Swae Lee)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "sativa");
 
     testString = "Get You (feat. Kali Uchis)";
@@ -30,32 +37,64 @@ public final class TitleFormatterTest {
     testString = "Promises (feat. Namiko, Miyagi & Miyagi & Namiko)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "promises");
 
-    testString = "WHATS POPPIN [Remix] (feat. DaBaby, Tory Lanez & Lil Wayne";
+    testString = "Tattoo (Remix)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "tattoo");
+  }
+
+  @Test
+  public void removeMultipleGroups() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+
+    String testString = "Savage (Remix) (feat. Beyoncé)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "savage");
+
+    testString = "Life is Good (Official Music Video) (feat. Drake)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "life is good");
+  }
+
+  @Test
+  public void removeMultipleGroupsSquareAndParen() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+
+    String testString = "WHATS POPPIN [Remix] (feat. DaBaby, Tory Lanez & Lil Wayne)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "whats poppin");
 
-    testString = "Juice WRLD ft. Marshmello - Come & Go (Official Audio)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
-
-    testString = "Savage (Remix) (feat. Beyoncé)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
-
-    testString = "BLACK PARADE";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "black parade");
+    testString = "Djadja [Remix] (feat. Afro B)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "djadja");
 
     testString = "Roses (Imanbek Remix) [Latino Gang]";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "roses");
+  }
 
-    testString = "Rod Wave - Girl Of My Dreams (Official Music Video)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "girl of my dreams");
+  @Test
+  public void removeValidGroups() {
+    TitleFormatter titleFormatter = new TitleFormatter();
 
-    testString = "ily (i love you baby) (feat. Emilee)";
+    String testString = "ily (i love you baby) (feat. Emilee)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "ily (i love you baby)");
 
     testString = "death bed (coffee for your head)";
     Assert.assertEquals(
         titleFormatter.formatVideoTitle(testString), "death bed (coffee for your head)");
+  }
 
-    testString = "Gucci Mane - Both Sides feat. Lil Baby";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
+  @Test
+  public void removeArtistPrefix() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+
+    String testString = "NBA YoungBoy - ALL IN";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "all in");
+  }
+
+  @Test
+  public void removeArtistPrefixAndGroup() {
+    TitleFormatter titleFormatter = new TitleFormatter();
+
+    String testString = "Juice WRLD ft. Marshmello - Come & Go (Official Audio)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
+
+    testString = "Rod Wave - Girl Of My Dreams (Official Music Video)";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "girl of my dreams");
 
     testString = "YG - Swag (Official Music Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "swag");
@@ -63,19 +102,18 @@ public final class TitleFormatterTest {
     testString = "Chase B & Don Toliver - Cafeteria (feat. Gunna) (Official Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "cafeteria");
 
-    testString = "NBA YoungBoy - ALL IN";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "all in");
-
     testString = "King Von - Why He Told (Official Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "why he told");
+  }
 
-    testString = "Tattoo (Remix)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "tattoo");
+  @Test
+  public void removeUnenclosedKeywords() {
+    TitleFormatter titleFormatter = new TitleFormatter();
 
-    testString = "Djadja [Remix] (feat. Afro B)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "djadja");
-
-    testString = "La Jeepeta Remix (Lyric Video)";
+    String testString = "La Jeepeta Remix (Lyric Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "la jeepeta");
+
+    testString = "Gucci Mane - Both Sides feat. Lil Baby";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
   }
 }

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -2,6 +2,7 @@ package com.google.songgame.data;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -108,7 +109,8 @@ public final class TitleFormatterTest {
 
   // TODO: @salilnadkarni add error checking for titles like this
   @Test
-  @Ignore("TitleFormatter unable to handle words not in brackets/parens") public void removeUnenclosedKeywords() {
+  @Ignore("TitleFormatter unable to handle words not in brackets/parens")
+  public void removeUnenclosedKeywords() {
     TitleFormatter titleFormatter = new TitleFormatter();
 
     String testString = "La Jeepeta Remix (Lyric Video)";
@@ -122,7 +124,5 @@ public final class TitleFormatterTest {
 
     testString = "BLACKPINK - 'How You Like That' M/V";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "how you like that");
-
   }
-  
 }

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -106,10 +106,9 @@ public final class TitleFormatterTest {
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "why he told");
   }
 
-  /*
   // TODO: @salilnadkarni add error checking for titles like this
   @Test
-  public void removeUnenclosedKeywords() {
+  @Ignore("TitleFormatter unable to handle words not in brackets/parens") public void removeUnenclosedKeywords() {
     TitleFormatter titleFormatter = new TitleFormatter();
 
     String testString = "La Jeepeta Remix (Lyric Video)";
@@ -122,8 +121,8 @@ public final class TitleFormatterTest {
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "supalonely");
 
     testString = "BLACKPINK - 'How You Like That' M/V";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "how you like that");    
-    
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "how you like that");
+
   }
-  */
+  
 }

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -106,6 +106,8 @@ public final class TitleFormatterTest {
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "why he told");
   }
 
+  /*
+  // TODO: @salilnadkarni add error checking for titles like this
   @Test
   public void removeUnenclosedKeywords() {
     TitleFormatter titleFormatter = new TitleFormatter();
@@ -116,4 +118,5 @@ public final class TitleFormatterTest {
     testString = "Gucci Mane - Both Sides feat. Lil Baby";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
   }
+  */
 }

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -117,6 +117,13 @@ public final class TitleFormatterTest {
 
     testString = "Gucci Mane - Both Sides feat. Lil Baby";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
+
+    testString = "ENEE - Supalonely (Audio) ft. Gus Dapperton";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "supalonely");
+
+    testString = "BLACKPINK - 'How You Like That' M/V";
+    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "how you like that");    
+    
   }
   */
 }

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -1,23 +1,29 @@
 package com.google.songgame.data;
 
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.Before;
 import org.junit.Ignore;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /*
+  Tests taken from the following playlist
   https://music.youtube.com/playlist?list=RDCLAK5uy_kmPRjHDECIcuVwnKsx2Ng7fyNgFKWNJFs
-
 */
 
 @RunWith(JUnit4.class)
 public final class TitleFormatterTest {
 
+  private TitleFormatter titleFormatter;
+
+  @Before
+  public void initializeTitleFormatter() {
+    titleFormatter = new TitleFormatter();
+  }
+
   @Test
   public void simpleCapitalization() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
     String testString = "Marvins Room";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "marvins room");
 
@@ -27,8 +33,6 @@ public final class TitleFormatterTest {
 
   @Test
   public void removeOneGroup() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
     String testString = "Sativa (ft. Swae Lee)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "sativa");
 
@@ -44,8 +48,6 @@ public final class TitleFormatterTest {
 
   @Test
   public void removeMultipleGroups() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
     String testString = "Savage (Remix) (feat. Beyoncé)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "savage");
 
@@ -54,9 +56,7 @@ public final class TitleFormatterTest {
   }
 
   @Test
-  public void removeMultipleGroupsSquareAndParen() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
+  public void removeMultipleGroupsSquareAndParenthesis() {
     String testString = "WHATS POPPIN [Remix] (feat. DaBaby, Tory Lanez & Lil Wayne)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "whats poppin");
 
@@ -68,9 +68,7 @@ public final class TitleFormatterTest {
   }
 
   @Test
-  public void removeValidGroups() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
+  public void removeOnlyInvalidParenthesisGroups() {
     String testString = "ily (i love you baby) (feat. Emilee)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "ily (i love you baby)");
 
@@ -81,16 +79,12 @@ public final class TitleFormatterTest {
 
   @Test
   public void removeArtistPrefix() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
     String testString = "NBA YoungBoy - ALL IN";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "all in");
   }
 
   @Test
   public void removeArtistPrefixAndGroup() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
     String testString = "Juice WRLD ft. Marshmello - Come & Go (Official Audio)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
 
@@ -111,8 +105,6 @@ public final class TitleFormatterTest {
   @Test
   @Ignore("TitleFormatter unable to handle words not in brackets/parens")
   public void removeUnenclosedKeywords() {
-    TitleFormatter titleFormatter = new TitleFormatter();
-
     String testString = "La Jeepeta Remix (Lyric Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "la jeepeta");
 

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -15,90 +15,83 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class TitleFormatterTest {
 
-  private TitleFormatter titleFormatter;
-
-  @Before
-  public void initializeTitleFormatter() {
-    titleFormatter = new TitleFormatter();
-  }
-
   @Test
   public void simpleCapitalization() {
     String testString = "Marvins Room";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "marvins room");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "marvins room");
 
     testString = "BLACK PARADE";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "black parade");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "black parade");
   }
 
   @Test
   public void removeOneGroup() {
     String testString = "Sativa (ft. Swae Lee)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "sativa");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "sativa");
 
     testString = "Get You (feat. Kali Uchis)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "get you");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "get you");
 
     testString = "Promises (feat. Namiko, Miyagi & Miyagi & Namiko)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "promises");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "promises");
 
     testString = "Tattoo (Remix)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "tattoo");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "tattoo");
   }
 
   @Test
   public void removeMultipleGroups() {
     String testString = "Savage (Remix) (feat. Beyoncé)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "savage");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "savage");
 
     testString = "Life is Good (Official Music Video) (feat. Drake)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "life is good");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "life is good");
   }
 
   @Test
   public void removeMultipleGroupsSquareAndParenthesis() {
     String testString = "WHATS POPPIN [Remix] (feat. DaBaby, Tory Lanez & Lil Wayne)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "whats poppin");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "whats poppin");
 
     testString = "Djadja [Remix] (feat. Afro B)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "djadja");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "djadja");
 
     testString = "Roses (Imanbek Remix) [Latino Gang]";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "roses");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "roses");
   }
 
   @Test
   public void removeOnlyInvalidParenthesisGroups() {
     String testString = "ily (i love you baby) (feat. Emilee)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "ily (i love you baby)");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "ily (i love you baby)");
 
     testString = "death bed (coffee for your head)";
     Assert.assertEquals(
-        titleFormatter.formatVideoTitle(testString), "death bed (coffee for your head)");
+        TitleFormatter.formatVideoTitle(testString), "death bed (coffee for your head)");
   }
 
   @Test
   public void removeArtistPrefix() {
     String testString = "NBA YoungBoy - ALL IN";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "all in");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "all in");
   }
 
   @Test
   public void removeArtistPrefixAndGroup() {
     String testString = "Juice WRLD ft. Marshmello - Come & Go (Official Audio)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "come & go");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "come & go");
 
     testString = "Rod Wave - Girl Of My Dreams (Official Music Video)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "girl of my dreams");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "girl of my dreams");
 
     testString = "YG - Swag (Official Music Video)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "swag");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "swag");
 
     testString = "Chase B & Don Toliver - Cafeteria (feat. Gunna) (Official Video)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "cafeteria");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "cafeteria");
 
     testString = "King Von - Why He Told (Official Video)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "why he told");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "why he told");
   }
 
   // TODO: @salilnadkarni add error checking for titles like this
@@ -106,15 +99,15 @@ public final class TitleFormatterTest {
   @Ignore("TitleFormatter unable to handle words not in brackets/parens")
   public void removeUnenclosedKeywords() {
     String testString = "La Jeepeta Remix (Lyric Video)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "la jeepeta");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "la jeepeta");
 
     testString = "Gucci Mane - Both Sides feat. Lil Baby";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "both sides");
 
     testString = "ENEE - Supalonely (Audio) ft. Gus Dapperton";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "supalonely");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "supalonely");
 
     testString = "BLACKPINK - 'How You Like That' M/V";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "how you like that");
+    Assert.assertEquals(TitleFormatter.formatVideoTitle(testString), "how you like that");
   }
 }

--- a/src/test/java/com/google/songgame/TitleFormatterTest.java
+++ b/src/test/java/com/google/songgame/TitleFormatterTest.java
@@ -1,4 +1,4 @@
-package com.google.songgame;
+package com.google.songgame.data;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,7 +51,8 @@ public final class TitleFormatterTest {
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "ily (i love you baby)");
 
     testString = "death bed (coffee for your head)";
-    Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "death bed (coffee for your head)");
+    Assert.assertEquals(
+        titleFormatter.formatVideoTitle(testString), "death bed (coffee for your head)");
 
     testString = "Gucci Mane - Both Sides feat. Lil Baby";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "both sides");
@@ -61,10 +62,10 @@ public final class TitleFormatterTest {
 
     testString = "Chase B & Don Toliver - Cafeteria (feat. Gunna) (Official Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "cafeteria");
-    
+
     testString = "NBA YoungBoy - ALL IN";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "all in");
-    
+
     testString = "King Von - Why He Told (Official Video)";
     Assert.assertEquals(titleFormatter.formatVideoTitle(testString), "why he told");
 


### PR DESCRIPTION
Improve answer checking capabilities of chat, simplifying youtube titles to the actual song title.
Use situational regex expressions and other string manipulation to cut out unecessary parts of title.
Created a `TitleFormatter` class to handle logic of song title formatting (techniques mentioned above).
Created a `TitleFormatterTest` class to test cases where the `TitleFormatter` should be used (taken from the playlist commented at the top of the class).
Set up testing infrastructure for Java (directory and changed `pom.xml` to add necessary plugins).
Kept testcases that currently give faulty answers, to handle at a latter point in time.

See in action:
https://screencast.googleplex.com/cast/NTYyNTQ4MzUzMjE3MzMxMnw2NmUzMjJlMy04Ng